### PR TITLE
Fixes spans v transactions typo in 6.4 docs

### DIFF
--- a/docs/transactions.asciidoc
+++ b/docs/transactions.asciidoc
@@ -22,7 +22,7 @@ Transactions are stored in <<transaction-indices, transaction indices>>.
 [[transaction-spans]]
 [float]
 === Spans
-Spans can have 0, 1, or many spans. Spans have a `transaction.id` attribute that refer to their transaction.
+Transactions can have 0, 1, or many spans. Spans have a `transaction.id` attribute that refer to their transaction.
 
 A span contains information about a specific code path,
 executed as part of a transaction. Such information includes start time, duration, name, type, and optionally a `stack trace`.


### PR DESCRIPTION
:wave: Still new here so not sure how the versioning stuff works with PRs like this, but looks like this typo was introduced in the 6.4 docs. I ran across it while reading through the docs. Feel free to close this and fix the one-word typo elsewhere if that makes more sense!